### PR TITLE
Stay in same activity when search button is clicked

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
         <activity
             android:name=".Activities.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:launchMode="singleInstance">
             <meta-data
                 android:name="android.app.searchable"
                 android:resource="@xml/searchable" />


### PR DESCRIPTION
When search button is clicked new activity opens even when the search results are displayed.
setting android:launchMode to singleinstance solves the problem.
.gif of bug attached
![ezgif-3-4833fbf28f42](https://user-images.githubusercontent.com/45128519/69399396-00abfd80-0d14-11ea-9adc-92faf3bdcc02.gif)
